### PR TITLE
Fix positioning of hero image in Safari

### DIFF
--- a/starter-files/public/sass/partials/_single.scss
+++ b/starter-files/public/sass/partials/_single.scss
@@ -28,6 +28,8 @@
   &__image {
     width: 100%;
     height: 100%;
+    top: 0;
+    left: 0;
     object-fit: cover;
     position: absolute;
   }


### PR DESCRIPTION
I noticed the the hero image styles in the starter-files for the single store view are rendered inconsistently on Chrome 58 and Safari 10.1 on macOS.

<img width="1680" alt="Chrome on left vs Safari on right" title="Chrome on left vs Safari on right" src="https://cloud.githubusercontent.com/assets/123200/25998210/27b950b6-3720-11e7-99ab-cb76cc866330.png">

This fix will put the image where it belongs.

On a side note, the fonts seem to be rendered differently too.