### PR TITLE
Update start.js

### DIFF
--- a/starter-files/start.js
+++ b/starter-files/start.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 
 // Make sure we are running node 7.6+
 const [major, minor] = process.versions.node.split('.').map(parseFloat);
-if (major <= 7 && minor <= 5) {
+if (major < 7 || (major = 7 && minor <= 5)) {
   console.log('🛑 🌮 🐶 💪 💩\nHey You! \n\t ya you! \n\t\tBuster! \n\tYou\'re on an older version of node that doesn\'t support the latest and greatest things we are learning (Async + Await)! Please go to nodejs.org and download version 7.6 or greater. 👌\n ');
   process.exit();
 }


### PR DESCRIPTION
Check the minor version number only when the major is 7, otherwise you might get a false negative (e.g. node version v6.9.4).