### PR TITLE
Accessibility fix for labelled form elements

### DIFF
--- a/stepped-solutions/11/views/mixins/_storeForm.pug
+++ b/stepped-solutions/11/views/mixins/_storeForm.pug
@@ -1,9 +1,9 @@
 mixin storeForm(store = {})
   form(action="/add" method="POST" class="card")
     label(for="name") Name
-    input(type="text" name="name")
+    input(type="text" name="name" id="name")
     label(for="description") Description
-    textarea(name="description")
+    textarea(name="description" id="description")
     - const choices = ['Wifi', 'Open Late', 'Family Friendly', 'Vegatarian', 'Licensed']
     ul.tags
       each choice in choices


### PR DESCRIPTION
The label's "for" attribute value needs to point to an id. Currently, we only include name attributes on form elements. Adding the id makes it so clicking the label text changes the cursor focus to the form element associated with the label.