### PR TITLE
[PR] => [Master] Updates the `tagQuery` to handle empty arrays.

### DIFF
--- a/stepped-solutions/23/controllers/storeController.js
+++ b/stepped-solutions/23/controllers/storeController.js
@@ -84,7 +84,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { $exists: true };
+  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/23/controllers/storeController.js
+++ b/stepped-solutions/23/controllers/storeController.js
@@ -84,7 +84,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
+  const tagQuery = tag || { $exists: true, $ne: [] };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/24/controllers/storeController.js
+++ b/stepped-solutions/24/controllers/storeController.js
@@ -84,7 +84,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { $exists: true };
+  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/24/controllers/storeController.js
+++ b/stepped-solutions/24/controllers/storeController.js
@@ -84,7 +84,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
+  const tagQuery = tag || { $exists: true, $ne: [] };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/25/controllers/storeController.js
+++ b/stepped-solutions/25/controllers/storeController.js
@@ -84,7 +84,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { $exists: true };
+  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/25/controllers/storeController.js
+++ b/stepped-solutions/25/controllers/storeController.js
@@ -84,7 +84,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
+  const tagQuery = tag || { $exists: true, $ne: [] };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/26/controllers/storeController.js
+++ b/stepped-solutions/26/controllers/storeController.js
@@ -84,7 +84,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { $exists: true };
+  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/26/controllers/storeController.js
+++ b/stepped-solutions/26/controllers/storeController.js
@@ -84,7 +84,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
+  const tagQuery = tag || { $exists: true, $ne: [] };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/27/controllers/storeController.js
+++ b/stepped-solutions/27/controllers/storeController.js
@@ -84,7 +84,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { $exists: true };
+  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/27/controllers/storeController.js
+++ b/stepped-solutions/27/controllers/storeController.js
@@ -84,7 +84,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
+  const tagQuery = tag || { $exists: true, $ne: [] };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/28/controllers/storeController.js
+++ b/stepped-solutions/28/controllers/storeController.js
@@ -84,7 +84,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { $exists: true };
+  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/28/controllers/storeController.js
+++ b/stepped-solutions/28/controllers/storeController.js
@@ -84,7 +84,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
+  const tagQuery = tag || { $exists: true, $ne: [] };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/29/controllers/storeController.js
+++ b/stepped-solutions/29/controllers/storeController.js
@@ -84,7 +84,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { $exists: true };
+  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/29/controllers/storeController.js
+++ b/stepped-solutions/29/controllers/storeController.js
@@ -84,7 +84,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
+  const tagQuery = tag || { $exists: true, $ne: [] };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/31/controllers/storeController.js
+++ b/stepped-solutions/31/controllers/storeController.js
@@ -92,7 +92,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { $exists: true };
+  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/31/controllers/storeController.js
+++ b/stepped-solutions/31/controllers/storeController.js
@@ -92,7 +92,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
+  const tagQuery = tag || { $exists: true, $ne: [] };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/32/controllers/storeController.js
+++ b/stepped-solutions/32/controllers/storeController.js
@@ -92,7 +92,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { $exists: true };
+  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/32/controllers/storeController.js
+++ b/stepped-solutions/32/controllers/storeController.js
@@ -92,7 +92,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
+  const tagQuery = tag || { $exists: true, $ne: [] };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/34/controllers/storeController.js
+++ b/stepped-solutions/34/controllers/storeController.js
@@ -92,7 +92,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { $exists: true };
+  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/34/controllers/storeController.js
+++ b/stepped-solutions/34/controllers/storeController.js
@@ -92,7 +92,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
+  const tagQuery = tag || { $exists: true, $ne: [] };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/35/controllers/storeController.js
+++ b/stepped-solutions/35/controllers/storeController.js
@@ -92,7 +92,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { $exists: true };
+  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/35/controllers/storeController.js
+++ b/stepped-solutions/35/controllers/storeController.js
@@ -92,7 +92,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
+  const tagQuery = tag || { $exists: true, $ne: [] };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/36/controllers/storeController.js
+++ b/stepped-solutions/36/controllers/storeController.js
@@ -93,7 +93,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { $exists: true };
+  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/36/controllers/storeController.js
+++ b/stepped-solutions/36/controllers/storeController.js
@@ -93,7 +93,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
+  const tagQuery = tag || { $exists: true, $ne: [] };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/37/controllers/storeController.js
+++ b/stepped-solutions/37/controllers/storeController.js
@@ -93,7 +93,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { $exists: true };
+  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/37/controllers/storeController.js
+++ b/stepped-solutions/37/controllers/storeController.js
@@ -93,7 +93,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
+  const tagQuery = tag || { $exists: true, $ne: [] };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/38/controllers/storeController.js
+++ b/stepped-solutions/38/controllers/storeController.js
@@ -93,7 +93,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { $exists: true };
+  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/38/controllers/storeController.js
+++ b/stepped-solutions/38/controllers/storeController.js
@@ -93,7 +93,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
+  const tagQuery = tag || { $exists: true, $ne: [] };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/39/controllers/storeController.js
+++ b/stepped-solutions/39/controllers/storeController.js
@@ -93,7 +93,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { $exists: true };
+  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/39/controllers/storeController.js
+++ b/stepped-solutions/39/controllers/storeController.js
@@ -93,7 +93,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
+  const tagQuery = tag || { $exists: true, $ne: [] };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/40/controllers/storeController.js
+++ b/stepped-solutions/40/controllers/storeController.js
@@ -93,7 +93,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { $exists: true };
+  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/40/controllers/storeController.js
+++ b/stepped-solutions/40/controllers/storeController.js
@@ -93,7 +93,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
+  const tagQuery = tag || { $exists: true, $ne: [] };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/45 - Finished App/controllers/storeController.js
+++ b/stepped-solutions/45 - Finished App/controllers/storeController.js
@@ -112,7 +112,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
+  const tagQuery = tag || { $exists: true, $ne: [] };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });

--- a/stepped-solutions/45 - Finished App/controllers/storeController.js
+++ b/stepped-solutions/45 - Finished App/controllers/storeController.js
@@ -112,7 +112,7 @@ exports.getStoreBySlug = async (req, res, next) => {
 
 exports.getStoresByTag = async (req, res) => {
   const tag = req.params.tag;
-  const tagQuery = tag || { $exists: true };
+  const tagQuery = tag || { tags: { $exists: true, $ne: [] } };
 
   const tagsPromise = Store.getTagsList();
   const storesPromise = Store.find({ tags: tagQuery });


### PR DESCRIPTION
This PR would update:
```
const tagQuery = tag || { $exists: true };
``` 
to :
```
{ $exists: true, $ne: [] }
```

This is because arrays in MongoDB (I believe) will be created with empty values i.e. `[]`. In MongoDB's docs it says 

> $exists matches the documents that contain the field, including documents where the field value is null". 

Of course `[] === null` is false.

There is a few ways you can handle this, I looked at this [Stack Overflow question](https://stackoverflow.com/questions/14789684/find-mongodb-records-where-array-field-is-not-empty-using-mongoose). I went with the example that seemed the most elegant. 

You can test this inside of Compass.

With the correct filter:
![image](https://user-images.githubusercontent.com/3174647/27066915-c43f3268-4fc4-11e7-9b01-a8bb1ae7af14.png)

With the filter in the video:
![image](https://user-images.githubusercontent.com/3174647/27066928-d7c6907e-4fc4-11e7-95d8-68a6aaf880b7.png)

With no filter:
![image](https://user-images.githubusercontent.com/3174647/27066941-e63a55e6-4fc4-11e7-8ae2-7c10737e7fd8.png)
