### PR TITLE
Update package.json browserslist to last 3 versions

### DIFF
--- a/starter-files/package.json
+++ b/starter-files/package.json
@@ -14,7 +14,7 @@
     "blowitallaway": "node ./data/load-sample-data.js --delete",
     "now": "now -e DB_USER=@db_user -e DB_PASS=@db_pass -e NODE_ENV=\"production\" -e PORT=80"
   },
-  "browserslist": "last 2 versions",
+  "browserslist": "last 3 versions",
   "dependencies": {
     "axios": "0.15.3",
     "body-parser": "1.17.1",

--- a/stepped-solutions/45 - Finished App/package.json
+++ b/stepped-solutions/45 - Finished App/package.json
@@ -16,7 +16,7 @@
     "sample": "node ./data/load-sample-data.js",
     "blowitallaway": "node ./data/load-sample-data.js --delete"
   },
-  "browserslist": "last 2 versions",
+  "browserslist": "last 3 versions",
   "dependencies": {
     "axios": "^0.15.3",
     "body-parser": "^1.17.1",


### PR DESCRIPTION
Noticed that browserslist in package.json is out of sync with the autoprefixer browserslist found in the webpack config: https://github.com/wesbos/Learn-Node/blob/sync-browserslist/stepped-solutions/45 - Finished App/webpack.config.js#L31

Don't think it matters much which way it goes (last 3, or last 2 versions), but it feels like it should be in sync. 

🙏 