### PR TITLE
💅 Make store grid more resilient

### DIFF
--- a/starter-files/public/sass/partials/_store.scss
+++ b/starter-files/public/sass/partials/_store.scss
@@ -1,13 +1,13 @@
 .stores {
   display:flex;
   flex-wrap:wrap;
-  justify-content:space-between;
+  margin: -1.25em 0 0 -1.25em;
 }
 
 .store {
   background:white;
-  margin: 10px 0;
-  width:30%;
+  margin: 1.25em 0 0 1.25em;
+  width: calc(33.3333% - 1.25em);
   box-shadow: $shad;
   &--wide {
     width: 100%;
@@ -20,7 +20,7 @@
     }
   }
   @media all and (max-width: 850px) {
-    width: 48%;
+    width: calc(50% - 1.25em);
   }
   @media all and (max-width: 550px) {
     width: 100%;


### PR DESCRIPTION
At larger viewports, a row containing 2 store cards are at either side, leaving an odd gap in the middle. Dropping flexbox's `space-between` property in favor of calculated widths and some margin magic helps mitigate this. Also leaves even spacing in between each card at all breakpoints.

Before 👇 
<img width="1257" alt="before" src="https://user-images.githubusercontent.com/1371573/28857488-b7c6dc32-76fe-11e7-9d57-2787e588df1a.png">

After fix 👇 
<img width="1249" alt="grid-fix" src="https://user-images.githubusercontent.com/1371573/28857585-64672ff0-76ff-11e7-864f-4426d127acc6.png">


