### PR TITLE
Fix gravatar generation from retro

### DIFF
--- a/starter-files/views/layout.pug
+++ b/starter-files/views/layout.pug
@@ -31,7 +31,7 @@ html
                 != h.icon('logout')
                 span Logout
               li.nav__item: a.nav__link(href="/account", class=(currentPath.startsWith('/account') ? 'nav__link--active' : ''))
-                img.avatar(src=user.gravatar + 'd=retro')
+                img.avatar(src=user.gravatar + '&d=retro')
             else
               li.nav__item: a.nav__link(href="/register", class=(currentPath.startsWith('/register') ? 'nav__link--active' : '')) Register
               li.nav__item: a.nav__link(href="/login", class=(currentPath.startsWith('/login') ? 'nav__link--active' : '')) Log In


### PR DESCRIPTION
Fix Gravatar generation from retro in case user's email does not have an image associated with it. The d attribute in the image src needs a '&' symbol before it.