### PR TITLE
allow load-sample-data to run before Review model exists

### DIFF
--- a/starter-files/data/load-sample-data.js
+++ b/starter-files/data/load-sample-data.js
@@ -7,19 +7,31 @@ mongoose.Promise = global.Promise; // Tell Mongoose to use ES6 promises
 
 // import all of our models - they need to be imported only once
 const Store = require('../models/Store');
-const Review = require('../models/Review');
 const User = require('../models/User');
 
+let hasReviewModel;
+let Review;
+try {
+  Review = require('../models/Review');
+  hasReviewModel = true;
+} catch(e) {
+  if (e.message === "Cannot find module '../models/Review'") {
+    hasReviewModel = false;
+  } else {
+    console.log(e);
+    process.exit();
+  }
+}
 
 const stores = JSON.parse(fs.readFileSync(__dirname + '/stores.json', 'utf-8'));
-const reviews = JSON.parse(fs.readFileSync(__dirname + '/reviews.json', 'utf-8'));
 const users = JSON.parse(fs.readFileSync(__dirname + '/users.json', 'utf-8'));
+const reviews = JSON.parse(fs.readFileSync(__dirname + '/reviews.json', 'utf-8'));
 
 async function deleteData() {
   console.log('😢😢 Goodbye Data...');
   await Store.remove();
-  await Review.remove();
   await User.remove();
+  if (hasReviewModel) await Review.remove();
   console.log('Data Deleted. To load sample data, run\n\n\t npm run sample\n\n');
   process.exit();
 }
@@ -27,8 +39,8 @@ async function deleteData() {
 async function loadData() {
   try {
     await Store.insertMany(stores);
-    await Review.insertMany(reviews);
     await User.insertMany(users);
+    if (hasReviewModel) await Review.insertMany(reviews);
     console.log('👍👍👍👍👍👍👍👍 Done!');
     process.exit();
   } catch(e) {


### PR DESCRIPTION
I ran into an issue in video number 30 (Loading Sample Data) where `npm run sample` would fail with the following error:

`Error: Cannot find module '../models/Review'`

It doesn't look like you write the review model until video number 37 so I've PR'd a potential fix for running load-sample-data before that point.