### PR TITLE
Typography fixes

### DIFF
--- a/starter-files/public/sass/partials/_helpers.scss
+++ b/starter-files/public/sass/partials/_helpers.scss
@@ -7,7 +7,7 @@
   border: 0;
   background: $yellow;
   color: $black;
-  font-family: 'Panama';
+  font-family: 'Panama', Arial, sans-serif;
   font-weight: 600;
 }
 

--- a/starter-files/public/sass/partials/_typography.scss
+++ b/starter-files/public/sass/partials/_typography.scss
@@ -18,7 +18,7 @@ body {
 
 h1, h2, h3, h4, h5, h6, {
   font-size: 5rem;
-  font-family: 'Panama';
+  font-family: 'Panama', Arial, sans-serif;
   font-weight: 600;
   letter-spacing:-1px;
 }

--- a/starter-files/public/sass/partials/_typography.scss
+++ b/starter-files/public/sass/partials/_typography.scss
@@ -67,6 +67,7 @@ p {
     border-bottom: 0;
     $yellowa: rgba($yellow,0.8);
     background-image: linear-gradient(to right, $yellowa 100%, $yellowa 50%);
+    text-transform: uppercase;
   }
 }
 

--- a/stepped-solutions/24/public/sass/partials/_helpers.scss
+++ b/stepped-solutions/24/public/sass/partials/_helpers.scss
@@ -7,7 +7,7 @@
   border: 0;
   background: $yellow;
   color: $black;
-  font-family: 'Panama';
+  font-family: 'Panama', Arial, sans-serif;
   font-weight: 600;
 }
 

--- a/stepped-solutions/24/public/sass/partials/_typography.scss
+++ b/stepped-solutions/24/public/sass/partials/_typography.scss
@@ -1,3 +1,12 @@
+@font-face {
+    font-family: 'panama';
+    src: url('/fonts/panama-bold-webfont.woff2') format('woff2'),
+         url('/fonts/panama-bold-webfont.woff') format('woff');
+    font-weight: normal;
+    font-style: normal;
+
+}
+
 html {
   font-size:10px;
 }

--- a/stepped-solutions/24/public/sass/partials/_typography.scss
+++ b/stepped-solutions/24/public/sass/partials/_typography.scss
@@ -9,7 +9,7 @@ body {
 
 h1, h2, h3, h4, h5, h6, {
   font-size: 5rem;
-  font-family: 'Panama';
+  font-family: 'Panama', Arial, sans-serif;
   font-weight: 600;
   letter-spacing:-1px;
 }

--- a/stepped-solutions/24/public/sass/partials/_typography.scss
+++ b/stepped-solutions/24/public/sass/partials/_typography.scss
@@ -58,6 +58,7 @@ p {
     border-bottom: 0;
     $yellowa: rgba($yellow,0.8);
     background-image: linear-gradient(to right, $yellowa 100%, $yellowa 50%);
+    text-transform: uppercase;
   }
 }
 

--- a/stepped-solutions/45 - Finished App/public/sass/partials/_helpers.scss
+++ b/stepped-solutions/45 - Finished App/public/sass/partials/_helpers.scss
@@ -7,7 +7,7 @@
   border: 0;
   background: $yellow;
   color: $black;
-  font-family: 'Panama';
+  font-family: 'Panama', Arial, sans-serif;
   font-weight: 600;
 }
 

--- a/stepped-solutions/45 - Finished App/public/sass/partials/_typography.scss
+++ b/stepped-solutions/45 - Finished App/public/sass/partials/_typography.scss
@@ -18,7 +18,7 @@ body {
 
 h1, h2, h3, h4, h5, h6, {
   font-size: 5rem;
-  font-family: 'Panama';
+  font-family: 'Panama', Arial, sans-serif;
   font-weight: 600;
   letter-spacing:-1px;
 }

--- a/stepped-solutions/45 - Finished App/public/sass/partials/_typography.scss
+++ b/stepped-solutions/45 - Finished App/public/sass/partials/_typography.scss
@@ -67,6 +67,7 @@ p {
     border-bottom: 0;
     $yellowa: rgba($yellow,0.8);
     background-image: linear-gradient(to right, $yellowa 100%, $yellowa 50%);
+    text-transform: uppercase;
   }
 }
 


### PR DESCRIPTION
1. 'Panama' font doesn't support cyrrilic, so any title written in Russian looks bad. 'Arial' looks pretty similar to 'Panama' and solves the problem. Also, it is good fallback for any situation when main font isn't loaded.
2. I guess those titles should be uppercased to look like in the videos.
3. Also, I found missing font-face declaration on step 24.

Btw, I updated some .scss, but I don't really know what to do with .css and .css.map files