### PR TITLE
Fixes logging out user after updating email

### DIFF
--- a/stepped-solutions/27/controllers/userController.js
+++ b/stepped-solutions/27/controllers/userController.js
@@ -54,6 +54,11 @@ exports.updateAccount = async (req, res) => {
     { $set: updates },
     { new: true, runValidators: true, context: 'query' }
   );
+  
+  req.login(user, err => {
+    console.log(err);
+  });
+
   req.flash('success', 'Updated the profile!');
   res.redirect('back');
 };


### PR DESCRIPTION
I noticed that when you update a user's email, you get immediately logged out. I imagine this is because Passport seeds its login token with the user's email, and once that changes, it no longer recognizes the login token as valid. I found this discussion: 
https://stackoverflow.com/questions/24493243/update-logged-in-user-details-in-session
which says that you need to re-login to update the session.