### PR TITLE
Update node-sass

### DIFF
--- a/starter-files/package.json
+++ b/starter-files/package.json
@@ -55,7 +55,7 @@
     "concurrently": "3.4.0",
     "css-loader": "0.27.3",
     "extract-text-webpack-plugin": "2.1.0",
-    "node-sass": "4.5.3",
+    "node-sass": "^4.7.2",
     "nodemon": "1.11.0",
     "now": "^6.4.1",
     "postcss-loader": "1.3.3",

--- a/stepped-solutions/45 - Finished App/package.json
+++ b/stepped-solutions/45 - Finished App/package.json
@@ -58,7 +58,7 @@
     "concurrently": "^3.4.0",
     "css-loader": "^0.27.3",
     "extract-text-webpack-plugin": "^2.1.0",
-    "node-sass": "^4.5.0",
+    "node-sass": "^4.7.2",
     "nodemon": "^1.11.0",
     "postcss-loader": "^1.3.3",
     "sass-loader": "^6.0.3",


### PR DESCRIPTION
Fix: outdated version of the node-sass module cannot download binaries (responded with 404) during installation process.