### PR TITLE
Update mongoose to 5.1.0

### DIFF
--- a/starter-files/package.json
+++ b/starter-files/package.json
@@ -35,7 +35,7 @@
     "juice": "4.0.2",
     "md5": "2.2.1",
     "moment": "2.17.1",
-    "mongoose": "4.8.7",
+    "mongoose": "5.1.0",
     "mongoose-mongodb-errors": "0.0.2",
     "multer": "1.3.0",
     "nodemailer": "3.1.5",


### PR DESCRIPTION
Updated mongoose to `5.1.0` in `package.json`.

Without this, using `aggregate()` causes the error `The cursor option is required, except for aggregate with the explain argument` when using MongoDB 3.6 or above.

**# 21 Custom MongoDB Aggregations**
```
// models/Store.js

storeSchema.statics.getTagsList = function () {
  return this.aggregate([
    ...
  ]);
};
```