### PR TITLE
Fix: Adding 'photo' to select value

### DIFF
--- a/stepped-solutions/34/controllers/storeController.js
+++ b/stepped-solutions/34/controllers/storeController.js
@@ -136,6 +136,6 @@ exports.mapStores = async (req, res) => {
     }
   };
 
-  const stores = await Store.find(q).select('slug name description location').limit(10);
+  const stores = await Store.find(q).select('slug name description location photo').limit(10);
   res.json(stores);
 };


### PR DESCRIPTION
In video "33: Creating a Geospatial Ajax Endpoint" you forgot to add the `photo` option in the select value. 

FYI, it does appears in the "34: Plotting Stores on a Custom Google Map" video and in stepped solutions 35 (which seems off by one number btw), but no mention of this is made which is pretty confusing when you get through video 34 and your photos are all broken! (You may want to consider adding a note in video 33).

Thanks!