### PR TITLE
handling promise inside of function instead of globally

### DIFF
--- a/starter-files/start.js
+++ b/starter-files/start.js
@@ -11,10 +11,8 @@ if (major < 7 || (major === 7 && minor <= 5)) {
 require('dotenv').config({ path: 'variables.env' });
 
 // Connect to our Database and handle any bad connections
-mongoose.connect(process.env.DATABASE);
-mongoose.Promise = global.Promise; // Tell Mongoose to use ES6 promises
-mongoose.connection.on('error', (err) => {
-  console.error(`🙅 🚫 🙅 🚫 🙅 🚫 🙅 🚫 → ${err.message}`);
+mongoose.connect(process.env.DATABASE, err => {
+  if (err) console.error(`🙅 🚫 🙅 🚫 🙅 🚫 🙅 🚫 → ${err}`);
 });
 
 // READY?! Let's go!


### PR DESCRIPTION
mongoose 5.4 uses es6 promises that can be handled inside of function.

We can also break the URI:
```js
mongoose.connect(process.env.MONGO_URI, {user: process.env.DB_USER, pass: process.env.DB_PASS}, err => {
    if (err) console.error(err);
});
```