### PR TITLE
Suppress "File is a CommonJS module" suggestion

### DIFF
--- a/starter-files/jsconfig.json
+++ b/starter-files/jsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "this_folder_should_never_appear"
+  },
+  "exclude": [
+    "node_modules",
+    "public"
+  ]
+}


### PR DESCRIPTION
When editing JavaScript files in VS Code, TypeScript will suggest converting any CommonJS module to an ES6 module, even for node.js backend code. Unfortunately, how TypeScript determines when to suppress or show this suggestion is flawed, especially in a combination frontend/backend project like this one where the frontend code can use ES6 modules through transpilation.

This adds a `jsconfig.json` file to the starter files that will suppress the spurious suggestions for the node.js code, but maintain the suggestion in the frontend code.

See these GitHub issues and pull requests for more details on the issue:

- https://github.com/Microsoft/vscode/issues/47299
- https://github.com/Microsoft/vscode/issues/47458
- https://github.com/Microsoft/TypeScript/issues/23391
- https://github.com/Microsoft/TypeScript/pull/23576
- https://github.com/Microsoft/TypeScript/pull/25721

- https://github.com/Microsoft/TypeScript/pull/25721#issuecomment-455877107
- https://github.com/Microsoft/TypeScript/issues/23391#issuecomment-455878381