### PR TITLE
Update nodemailer version

### DIFF
--- a/starter-files/package.json
+++ b/starter-files/package.json
@@ -38,7 +38,7 @@
     "mongoose": "5.1.0",
     "mongoose-mongodb-errors": "0.0.2",
     "multer": "1.3.0",
-    "nodemailer": "3.1.5",
+    "nodemailer": "^4.0.1",
     "passport": "0.3.2",
     "passport-local": "1.0.0",
     "passport-local-mongoose": "4.0.0",


### PR DESCRIPTION
The version specified in the package.json is 3.1.5, which has been deprecated. Updated it to 4.0.1 and above, which are the versions currently supported.

Issue: Error message during npm install: 
"npm WARN deprecated nodemailer@3.1.5: All versions below 4.0.1 of Nodemailer are deprecated. See https://nodemailer.com/status/"