### PR TITLE
Update production deployment config

### DIFF
--- a/starter-files/package.json
+++ b/starter-files/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "prod": "node ./start.js",
+    "build": "webpack",
     "watch": "nodemon ./start.js --ignore public/",
     "start": "concurrently \"npm run watch\" \"npm run assets\" --names \"💻,📦\" --prefix name",
     "assets": "webpack -w",

--- a/starter-files/webpack.config.js
+++ b/starter-files/webpack.config.js
@@ -4,7 +4,7 @@
 const path = require("path");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const env = require("dotenv").config({ path: "variables.env" });
-const nodeEnv = env.parsed.NODE_ENV;
+const nodeEnv = process.env.NODE_ENV || env.parsed.NODE_ENV;
 
 /*
   webpack sees every file as a module.

--- a/stepped-solutions/45 - Finished App/package.json
+++ b/stepped-solutions/45 - Finished App/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "prod": "node ./start.js",
+    "build": "webpack",
     "watch": "nodemon ./start.js --ignore public/",
     "start": "concurrently \"npm run watch\" \"npm run assets\" --names \"💻,📦\" --prefix name",
     "assets": "webpack -w",

--- a/stepped-solutions/45 - Finished App/webpack.config.js
+++ b/stepped-solutions/45 - Finished App/webpack.config.js
@@ -4,7 +4,7 @@
 const path = require("path");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const env = require("dotenv").config({ path: "variables.env" });
-const nodeEnv = env.parsed.NODE_ENV;
+const nodeEnv = process.env.NODE_ENV || env.parsed.NODE_ENV;
 
 /*
   webpack sees every file as a module.


### PR DESCRIPTION
Hi @wesbos 👋 

Someone had a bit of an issue with deploying to Heroku after I updated the starter files, this PR adds a `build` npm script to build the CSS and JS code when it deploys.

It also fixes Webpack 5 to read the `process.env.NODE_ENV` variable if it exists on Heroku instead of looking for a `variables.env` file (which doesn't exist on deployment) - I accidentally hard-coded that it should look for that file. 😓 

I was able to deploy it to production myself after making these 2 changes 🙂 
https://learn-node-test.herokuapp.com/