### PR TITLE
set Node version to 16.14.0 in package.json files

### DIFF
--- a/starter-files/package-lock.json
+++ b/starter-files/package-lock.json
@@ -57,7 +57,8 @@
         "webpack-cli": "4.9.1"
       },
       "engines": {
-        "node": ">= 7.6.0"
+        "node": "16.14.0",
+        "npm": "8.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/starter-files/package.json
+++ b/starter-files/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "engines": {
-    "node": ">= 7.6.0"
+    "node": "16.14.0",
+    "npm": "8.x"
   },
   "scripts": {
     "prod": "node ./start.js",

--- a/stepped-solutions/45 - Finished App/package-lock.json
+++ b/stepped-solutions/45 - Finished App/package-lock.json
@@ -57,7 +57,8 @@
         "webpack-cli": "4.9.1"
       },
       "engines": {
-        "node": ">= 7.6.0"
+        "node": "16.14.0",
+        "npm": "8.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/stepped-solutions/45 - Finished App/package.json
+++ b/stepped-solutions/45 - Finished App/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "engines": {
-    "node": ">= 7.6.0"
+    "node": "16.14.0",
+    "npm": "8.x"
   },
   "scripts": {
     "prod": "node ./start.js",


### PR DESCRIPTION
Hey @wesbos 👋 

A few people ran into issues with Heroku deployments with the course. Heroku tries to use Node 17 by default and it's throwing errors.

This PR sets the Node version in the `package.json` file to `16.14.0` so that Heroku can detect and use that instead.